### PR TITLE
Include automation hash in Automation Response

### DIFF
--- a/src/common/Fetcher.ts
+++ b/src/common/Fetcher.ts
@@ -23,6 +23,10 @@ export class Fetcher {
       `${AUTOMATIONS_BASE_URL}/${endpoint}`,
       updatedOptions,
     )
-    return res.json()
+    if (!res.ok) {
+      throw new Error('Request failed')
+    } else {
+      return res.json()
+    }
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -78,6 +78,7 @@ export type SignAutomationParams = {
 export type AutomationResponse = {
   id: string
   account: string
+  hash: Hex
   validator: string
   network: number
   maxNumberOfExecutions: number


### PR DESCRIPTION
# Implements
- Extend `AutomationResponse` to include automation hash returned by API
- Conditionally parse all `response.json()` if responses is ok. More robust status code parsing required